### PR TITLE
Make all tests runnable on Python 3.4 but still fail almost tests

### DIFF
--- a/beproud/django/commons/forms/__init__.py
+++ b/beproud/django/commons/forms/__init__.py
@@ -1,3 +1,4 @@
-from fields import *
-from utils import *
-from forms import *
+from __future__ import absolute_import
+from .fields import *
+from .utils import *
+from .forms import *

--- a/beproud/django/commons/middleware/debug.py
+++ b/beproud/django/commons/middleware/debug.py
@@ -7,5 +7,5 @@ class DebugMiddleware(object):
         if settings.DEBUG: 
             from django.db import connection
             for query in connection.queries:
-                print query
+                print(query)
         return response

--- a/beproud/django/commons/models/__init__.py
+++ b/beproud/django/commons/models/__init__.py
@@ -1,3 +1,4 @@
-from base import *
-from fields import *
-from utils import *
+from __future__ import absolute_import
+from .base import *
+from .fields import *
+from .utils import *

--- a/beproud/django/commons/models/fields.py
+++ b/beproud/django/commons/models/fields.py
@@ -1,5 +1,6 @@
 #:coding=utf-8:
 
+import sys
 import base64
 import warnings
 
@@ -16,7 +17,12 @@ except ImportError:
 from django import VERSION as DJANGO_VERSION
 from django.core import exceptions
 from django.utils.translation import ugettext_lazy as _
-from django.db import load_backend
+
+if DJANGO_VERSION > (1, 7):
+    from django.db.utils import load_backend
+else:
+    from django.db import load_backend
+
 from django.db.models import BigIntegerField
 
 from django.db import models
@@ -32,6 +38,10 @@ __all__ = (
     'PickledObjectField',
     'JSONField',
 )
+
+
+if sys.version_info[0] == 3:
+    long = int
 
 
 class BigAutoField(models.AutoField):

--- a/beproud/django/commons/templatetags/googlead_tags.py
+++ b/beproud/django/commons/templatetags/googlead_tags.py
@@ -22,7 +22,7 @@ class GoogleAdNode(Node):
 
             return render_to_string(template_name, context_dict)
 
-        except TemplateDoesNotExist,e:
+        except TemplateDoesNotExist as e:
             return ''
 
 @register.tag

--- a/beproud/django/commons/test/__init__.py
+++ b/beproud/django/commons/test/__init__.py
@@ -1,1 +1,2 @@
-from simple import *
+from __future__ import absolute_import
+from .simple import *

--- a/beproud/django/commons/test/simple.py
+++ b/beproud/django/commons/test/simple.py
@@ -5,7 +5,12 @@ try:
 except ImportError:
     import simplejson as json
 
-from types import StringType, UnicodeType
+import sys
+if sys.version_info[0] == 2:
+    from types import StringType, UnicodeType
+elif sys.version_info[0] == 3:
+    StringType = bytes
+    UnicodeType = str
 from django.test import TestCase
 
 __all__ = (
@@ -88,7 +93,7 @@ class RequestTestCase(TestCase):
     def assertJson(self, response):
         try:
             return json.loads(response.content)
-        except ValueError, e:
+        except ValueError as e:
             self.fail(e.message)
 
     def assertXml(self, response):
@@ -96,7 +101,7 @@ class RequestTestCase(TestCase):
         try:
             p = expat.ParserCreate()
             return p.Parse(response.content)
-        except expat.ExpatError, e:
+        except expat.ExpatError as e:
             self.fail(e.message)
 
     def _assertLocationHeader(self, response, redirect_url=None):

--- a/beproud/django/commons/tests/test_template.py
+++ b/beproud/django/commons/tests/test_template.py
@@ -2,9 +2,18 @@
 
 from django import VERSION as DJANGO_VERSION
 from django.test import TestCase as DjangoTestCase
-from django.template import Template, Lexer, Parser, TemplateSyntaxError
+from django.template import Template, TemplateSyntaxError
 from django.template.loader import LoaderOrigin 
 from django.template.context import Context
+
+if DJANGO_VERSION > (1, 7):
+    from django.template.base import Lexer, Parser, import_library
+else:
+    from django.template import Lexer, Parser
+    if DJANGO_VERSION > (1, 2):
+        from django.template import import_library
+    else:
+        from django.template import get_library as import_library
 
 
 class BaseTemplateTagTest(object):
@@ -13,13 +22,7 @@ class BaseTemplateTagTest(object):
         return LoaderOrigin("Commons Test", lambda x,y: ("<string>", "<string>"), "commons", [])
 
     def _render_html(self, template_string, context={}):
-        # :(
-        if DJANGO_VERSION > (1,2):
-            from django.template import import_library
-            tag_lib = import_library('beproud.django.commons.tests.test_tags')
-        else:
-            from django.template import get_library
-            tag_lib = get_library('beproud.django.commons.tests.test_tags')
+        tag_lib = import_library('beproud.django.commons.tests.test_tags')
 
         lexer = Lexer(template_string, self._make_origin())
         parser = Parser(lexer.tokenize())
@@ -35,12 +38,12 @@ class DataTemplateTagTestCase(BaseTemplateTagTest, DjangoTestCase):
 
     def test_data_template_tag(self):
         self.assertEquals(self._render_html(self.TEMPLATE_STRING), "<html><body>MY DATA</body></html>")
-    
+
     def test_bad_template_tag(self):
         try:
             html = self._render_html(self.BAD_TEMPLATE_STRING)
             self.fail("Expected Fail: %s" % html)
-        except TemplateSyntaxError, e:
+        except TemplateSyntaxError as e:
             pass
 
 class KwargDataTemplateTagTestCase(BaseTemplateTagTest, DjangoTestCase):
@@ -76,12 +79,12 @@ class KwargDataTemplateTagTestCase(BaseTemplateTagTest, DjangoTestCase):
         try:
             html = self._render_html(self.BAD_TEMPLATE_STRING1)
             self.fail("Expected Fail: %s" % html)
-        except TemplateSyntaxError, e:
+        except TemplateSyntaxError as e:
             pass
 
     def test_bad_template_tag2(self):
         try:
             html = self._render_html(self.BAD_TEMPLATE_STRING2)
             self.fail("Expected Fail: %s" % html)
-        except TemplateSyntaxError, e:
+        except TemplateSyntaxError as e:
             pass

--- a/beproud/django/commons/tests/test_templatetags.py
+++ b/beproud/django/commons/tests/test_templatetags.py
@@ -2,7 +2,11 @@
 
 import os
 
-from BeautifulSoup import BeautifulSoup
+try:
+    from BeautifulSoup import BeautifulSoup
+except ImportError:
+    from bs4 import BeautifulSoup
+
 
 from django.test import TestCase as DjangoTestCase
 from django.conf import settings

--- a/beproud/django/commons/utils/javascript.py
+++ b/beproud/django/commons/utils/javascript.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     import simplejson as json
 
-from django.utils.encoding import force_unicode
+from django.utils.encoding import force_text
 
 from beproud.utils.javascript import escapejs_json, SafeJSONEncoder
 
@@ -23,6 +23,6 @@ class DjangoJSONEncoder(SafeJSONEncoder):
             # lazy翻訳オブジェクトなどの対応
             from django.utils.functional import Promise
             if isinstance(obj, Promise):
-                return escapejs_json(force_unicode(obj))
+                return escapejs_json(force_text(obj))
             else:
                 raise

--- a/beproud/django/commons/views/__init__.py
+++ b/beproud/django/commons/views/__init__.py
@@ -1,2 +1,3 @@
-from simple import *
-from classes import *
+from __future__ import absolute_import
+from .simple import *
+from .classes import *

--- a/docs/ja/source/conf.py
+++ b/docs/ja/source/conf.py
@@ -169,8 +169,8 @@ htmlhelp_basename = 'bpcommonsdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class [howto/manual]).
 latex_documents = [
-  ('index', 'bpcommonsdoc.tex', ur'bpcommons Documentation',
-   ur'K.K. BeProud', 'manual'),
+  ('index', 'bpcommonsdoc.tex', u'bpcommons Documentation',
+   u'K.K. BeProud', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/tox.ini
+++ b/tox.ini
@@ -2,18 +2,21 @@
 
 [tox]
 
-envlist = {py26,py27}-django{14,15,16}, py27-django17
+envlist = {py26,py27}-django{14,15,16}, {py27,py34}-django{17,18}
 
 [testenv]
 basepython =
     py26: python2.6
     py27: python2.7
+    py34: python3.4
 deps =
     https://github.com/beproud/bputils/archive/v0.34.zip
-    BeautifulSoup==3.2.0
+    py{26,27}: BeautifulSoup==3.2.0
+    py34: beautifulsoup4==4.4.0
     zenhan==0.4
     django14: Django>=1.4,<1.5
     django15: Django>=1.5,<1.6
     django16: Django>=1.6,<1.7
     django17: Django>=1.7,<1.8
+    django18: Django>=1.8,<1.9
 commands=python setup.py test


### PR DESCRIPTION
This PR is an example of fixing for Django 1.8 and Python 3.
(You do NOT have to merge this PR)

## Support Django 1.8

* Add new tox environments to test Django 1.8
* Follow classes and functions' move 

## Ready for Python 3

Now we can run all tests on Python 3.4 but **still almost tests are failed**.
IMO, a compat module is required to avoid using `six` to solve compatibility problems.