### PR TITLE
Fix: #26 compare_obj, copy_obj で AttributeError が発生する

### DIFF
--- a/beproud/django/commons/models/utils.py
+++ b/beproud/django/commons/models/utils.py
@@ -7,6 +7,7 @@ __all__ = (
     'copy_obj',
 )
 
+
 def compare_obj(base_obj, new_obj, check_primary_key=False, check_related=False, exclude=[], check_related_id=False, display=False):
     """
     モデルインスタンスの比較を行う
@@ -16,23 +17,23 @@ def compare_obj(base_obj, new_obj, check_primary_key=False, check_related=False,
     for field in base_obj._meta.fields:
         if field.primary_key and not check_primary_key:
             continue
-        if field.rel and not check_related:
+        if field.remote_field and not check_related:
             continue
         if field.name in exclude:
             continue
-        if field.rel and check_related_id:
+        if field.remote_field and check_related_id:
             v1 = getattr(base_obj, field.name + '_id')
             v2 = getattr(new_obj, field.name + '_id')
         else:
             v1 = getattr(base_obj, field.name)
             v2 = getattr(new_obj, field.name)
         if v1 != v2:
-            if field.choices or field.rel and display:
-                if field.rel and v1 is None:
+            if field.choices or field.remote_field and display:
+                if field.remote_field and v1 is None:
                     _v1 = None
                 else:
                     _v1 = getattr(base_obj, field.name)
-                if field.rel and v2 is None:
+                if field.remote_field and v2 is None:
                     _v2 = None
                 else:
                     _v2 = getattr(new_obj, field.name)
@@ -70,6 +71,7 @@ def compare_obj(base_obj, new_obj, check_primary_key=False, check_related=False,
             )
     return diff_dict
 
+
 def copy_obj(from_obj, to_obj, check_primary_key=False, check_related=False, exclude=[], copy_related_id=False, check_many_to_many=False):
     """
     モデルインスタンスのフィールドの内容をコピーする
@@ -77,11 +79,11 @@ def copy_obj(from_obj, to_obj, check_primary_key=False, check_related=False, exc
     for field in from_obj._meta.fields:
         if field.primary_key and not check_primary_key:
             continue
-        if field.rel and not check_related:
+        if field.remote_field and not check_related:
             continue
         if field.name in exclude:
             continue
-        if field.rel and copy_related_id:
+        if field.remote_field and copy_related_id:
             v = getattr(from_obj, field.name + '_id')
             setattr(to_obj, field.name + '_id', v)
         else:

--- a/tests/test_models_utils.py
+++ b/tests/test_models_utils.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime
+
+import pytest
+import factory
+
+from models.base.models import BaseModel
+
+
+__all__ = (
+    'TestCompareModel',
+    'TestCopyModel',
+)
+
+
+class BaseModelFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = BaseModel
+
+
+@pytest.mark.django_db
+class TestCompareModel(object):
+
+    @pytest.fixture
+    def target(self):
+        from beproud.django.commons.models.utils import compare_obj
+        return compare_obj
+
+    def test_simple(self, target):
+        base_obj = BaseModelFactory.create(del_flg=False)
+        new_obj = BaseModelFactory.create(del_flg=True)
+        result = target(base_obj, new_obj)
+
+        del_flg_field = BaseModel._meta.get_field("del_flg")
+        assert result[del_flg_field] == (False, True)
+
+
+@pytest.mark.django_db
+class TestCopyModel(object):
+
+    @pytest.fixture
+    def target(self):
+        from beproud.django.commons.models.utils import copy_obj
+        return copy_obj
+
+    def test_simple(self, target):
+        from_obj = BaseModelFactory.create(utime=datetime(2020, 4, 20))
+        to_obj = BaseModel()
+        target(from_obj, to_obj)
+
+        assert from_obj.id != to_obj.id
+        assert from_obj.ctime == to_obj.ctime
+        assert from_obj.utime == to_obj.utime
+        assert from_obj.del_flg == to_obj.del_flg

--- a/tests/test_models_utils.py
+++ b/tests/test_models_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from datetime import datetime
 
 import pytest
@@ -51,4 +50,4 @@ class TestCopyModel(object):
         assert from_obj.id != to_obj.id
         assert from_obj.ctime == to_obj.ctime
         assert from_obj.utime == to_obj.utime
-        assert from_obj.del_flg == to_obj.del_flg
+        assert from_obj.del_flg is to_obj.del_flg


### PR DESCRIPTION
#26 の修正

FIX: Field.rel and Field.remote_field.to are removed. (Deplicated in 1.9 and Removed in 2.0)
https://docs.djangoproject.com/en/3.0/releases/2.0/#features-removed-in-2-0